### PR TITLE
Improve odometry and map thread safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ find_package(std_srvs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(pcl_ros REQUIRED)
 find_package(pcl_conversions REQUIRED)
 
 # 必须用 SaveTraj 这种格式，save_traj 不行
@@ -49,9 +48,8 @@ set(dependencies
   nav_msgs
   std_msgs
   std_srvs
-  pcl_ros
   pcl_conversions
-  tf2_ros 
+  tf2_ros
 )
 
 find_package(Eigen3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 # 必须用 SaveTraj 这种格式，save_traj 不行
 # ros2中对自定义消息的名字有要求，首字母必须大写，中介不能有下划线等

--- a/config/dlo.yaml
+++ b/config/dlo.yaml
@@ -5,11 +5,11 @@
       adaptiveParams: true
       imu: true
       gravityAlign: true
-      publishTF: true
 
       odomNode:
         odom_frame: odom
         child_frame: base_link
+        publishTF: true
 
       mapNode:
         publishFullMap: true

--- a/include/dlo/dlo.h
+++ b/include/dlo/dlo.h
@@ -13,6 +13,7 @@
 #include <iomanip>
 #include <iostream>
 #include <mutex>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <sys/times.h>

--- a/include/dlo/map.h
+++ b/include/dlo/map.h
@@ -48,6 +48,7 @@ private:
 
   pcl::PointCloud<PointType>::Ptr dlo_map;
   pcl::VoxelGrid<PointType> voxelgrid;
+  std::mutex map_mutex_;
 
   rclcpp::Time map_stamp;
   std::string odom_frame;

--- a/include/dlo/odom.h
+++ b/include/dlo/odom.h
@@ -213,11 +213,20 @@ private:
   std::thread debug_thread;
 
   std::mutex mtx_imu;
+  std::mutex cloud_mutex_;
+  std::mutex pose_mutex_;
+  std::mutex keyframe_mutex_;
+  std::mutex trajectory_mutex_;
+  std::mutex metrics_mutex_;
+  std::mutex debug_mutex_;
+  std::mutex keyframe_publish_mutex_;
 
   std::string cpu_type;
   std::vector<double> cpu_percents;
   clock_t lastCPU, lastSysCPU, lastUserCPU;
   int numProcessors;
+
+  float spaciousness_median_prev_;
 
   // Parameters
   std::string version_;

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>std_srvs</depend>
   <depend>common_interfaces</depend>
   <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>pcl_conversions</depend>
 
 

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,6 @@
   <depend>std_srvs</depend>
   <depend>common_interfaces</depend>
   <depend>tf2</depend>
-  <depend>pcl_ros</depend>
   <depend>pcl_conversions</depend>
 
 

--- a/src/dlo/map.cc
+++ b/src/dlo/map.cc
@@ -126,15 +126,22 @@ void MapNode::abortTimerCB() {
 
 void MapNode::publishTimerCB() {
 
-  if (this->dlo_map->points.size() == this->dlo_map->width * this->dlo_map->height) {
-    sensor_msgs::msg::PointCloud2 map_ros;
-    pcl::toROSMsg(*this->dlo_map, map_ros);
+  sensor_msgs::msg::PointCloud2 map_ros;
+  bool publish = false;
+  {
+    std::lock_guard<std::mutex> lock(this->map_mutex_);
+    if (this->dlo_map->points.size() == this->dlo_map->width * this->dlo_map->height) {
+      pcl::toROSMsg(*this->dlo_map, map_ros);
+      publish = true;
+    }
+  }
+
+  if (publish) {
     map_ros.header.stamp = this->get_clock()->now();
     map_ros.header.frame_id = this->odom_frame;
     this->map_pub->publish(map_ros);
-
   }
-  
+
 }
 
 
@@ -154,8 +161,11 @@ void MapNode::keyframeCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& ke
   this->voxelgrid.filter(*keyframe_pcl);
 
   // save keyframe to map
-  this->map_stamp = keyframe->header.stamp;
-  *this->dlo_map += *keyframe_pcl;
+  {
+    std::lock_guard<std::mutex> lock(this->map_mutex_);
+    this->map_stamp = keyframe->header.stamp;
+    *this->dlo_map += *keyframe_pcl;
+  }
 
   if (!this->publish_full_map_) {
     if (keyframe_pcl->points.size() == keyframe_pcl->width * keyframe_pcl->height) {

--- a/src/dlo/odom.cc
+++ b/src/dlo/odom.cc
@@ -157,6 +157,8 @@ void OdomNode::init()
   this->imu_buffer.set_capacity(this->imu_buffer_size_);
   this->first_imu_time = 0.;
 
+  this->spaciousness_median_prev_ = 0.f;
+
 
   this->original_scan = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
   this->current_scan = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
@@ -415,6 +417,8 @@ void OdomNode::publishToROS() {
 
 void OdomNode::publishPose() {
 
+  std::lock_guard<std::mutex> lock(this->pose_mutex_);
+
   // Sign flip check
   static Eigen::Quaternionf q_diff{1., 0., 0., 0.};
   static Eigen::Quaternionf q_last{1., 0., 0., 0.};
@@ -465,7 +469,7 @@ void OdomNode::publishPose() {
 
 void OdomNode::publishTransform() {
 
-
+  std::lock_guard<std::mutex> lock(this->pose_mutex_);
   geometry_msgs::msg::TransformStamped transformStamped;
 
   transformStamped.header.stamp = this->scan_stamp;
@@ -492,6 +496,8 @@ void OdomNode::publishTransform() {
 
 void OdomNode::publishKeyframe() {
 
+  std::scoped_lock lock(this->keyframe_publish_mutex_, this->pose_mutex_, this->keyframe_mutex_);
+
   // Publish keyframe pose
   this->kf.header.stamp = this->scan_stamp;
   this->kf.header.frame_id = this->odom_frame;
@@ -509,7 +515,8 @@ void OdomNode::publishKeyframe() {
   this->kf_pub->publish(this->kf);
 
   // Publish keyframe scan
-  if (this->keyframe_cloud->points.size() == this->keyframe_cloud->width * this->keyframe_cloud->height) {
+  if (this->keyframe_cloud && !this->keyframe_cloud->empty() &&
+      this->keyframe_cloud->points.size() == this->keyframe_cloud->width * this->keyframe_cloud->height) {
     sensor_msgs::msg::PointCloud2 keyframe_cloud_ros;
     pcl::toROSMsg(*this->keyframe_cloud, keyframe_cloud_ros);
     keyframe_cloud_ros.header.stamp = this->scan_stamp;
@@ -525,6 +532,13 @@ void OdomNode::publishKeyframe() {
  **/
 
 void OdomNode::preprocessPoints() {
+
+  std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+
+  if (!this->current_scan) {
+    RCLCPP_WARN(this->get_logger(), "Current scan is null. Skipping preprocessing.");
+    return;
+  }
 
   // Original Scan
   *this->original_scan = *this->current_scan;
@@ -555,17 +569,32 @@ void OdomNode::preprocessPoints() {
 
 void OdomNode::initializeInputTarget() {
 
-  this->prev_frame_stamp = this->curr_frame_stamp;
+  pcl::PointCloud<PointType>::Ptr current_scan;
+  Eigen::Matrix4f current_T = Eigen::Matrix4f::Identity();
+  Eigen::Vector3f current_pose = Eigen::Vector3f::Zero();
+  Eigen::Quaternionf current_rot = Eigen::Quaternionf::Identity();
 
-  // Convert ros message
-  this->target_cloud = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
-  this->target_cloud = this->current_scan;
+  {
+    std::scoped_lock lock(this->pose_mutex_, this->cloud_mutex_);
+    this->prev_frame_stamp = this->curr_frame_stamp;
+    current_scan = this->current_scan;
+    current_T = this->T;
+    current_pose = this->pose;
+    current_rot = this->rotq;
+  }
+
+  if (!current_scan) {
+    RCLCPP_WARN(this->get_logger(), "Current scan is null. Unable to initialize target cloud.");
+    return;
+  }
+
+  this->target_cloud = current_scan;
   this->gicp_s2s.setInputTarget(this->target_cloud);
   this->gicp_s2s.calculateTargetCovariances();
 
   // initialize keyframes
   pcl::PointCloud<PointType>::Ptr first_keyframe (new pcl::PointCloud<PointType>);
-  pcl::transformPointCloud (*this->target_cloud, *first_keyframe, this->T);
+  pcl::transformPointCloud (*this->target_cloud, *first_keyframe, current_T);
 
   // voxelization for submap
   if (this->vf_submap_use_) {
@@ -573,20 +602,22 @@ void OdomNode::initializeInputTarget() {
     this->vf_submap.filter(*first_keyframe);
   }
 
-  // keep history of keyframes
-  this->keyframes.push_back(std::make_pair(std::make_pair(this->pose, this->rotq), first_keyframe));
-  *this->keyframes_cloud += *first_keyframe;
-  *this->keyframe_cloud = *first_keyframe;
+  {
+    std::lock_guard<std::mutex> key_lock(this->keyframe_mutex_);
+    this->keyframes.push_back(std::make_pair(std::make_pair(current_pose, current_rot), first_keyframe));
+    *this->keyframes_cloud += *first_keyframe;
+    *this->keyframe_cloud = *first_keyframe;
 
-  // compute kdtree and keyframe normals (use gicp_s2s input source as temporary storage because it will be overwritten by setInputSources())
-  this->gicp_s2s.setInputSource(this->keyframe_cloud);
-  this->gicp_s2s.calculateSourceCovariances();
-  this->keyframe_normals.push_back(this->gicp_s2s.getSourceCovariances());
+    // compute kdtree and keyframe normals (use gicp_s2s input source as temporary storage because it will be overwritten by setInputSources())
+    this->gicp_s2s.setInputSource(this->keyframe_cloud);
+    this->gicp_s2s.calculateSourceCovariances();
+    this->keyframe_normals.push_back(this->gicp_s2s.getSourceCovariances());
+
+    ++this->num_keyframes;
+  }
 
   this->publish_keyframe_thread = std::thread(&OdomNode::publishKeyframe, this );
   this->publish_keyframe_thread.detach();
-
-  ++this->num_keyframes;
 
 }
 
@@ -597,13 +628,24 @@ void OdomNode::initializeInputTarget() {
 
 void OdomNode::setInputSources(){
 
+  pcl::PointCloud<PointType>::Ptr current_scan;
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    current_scan = this->current_scan;
+  }
+
+  if (!current_scan) {
+    RCLCPP_WARN(this->get_logger(), "Current scan is null. Unable to set input sources.");
+    return;
+  }
+
   // set the input source for the S2S gicp
   // this builds the KdTree of the source cloud
   // this does not build the KdTree for s2m because force_no_update is true
-  this->gicp_s2s.setInputSource(this->current_scan);
+  this->gicp_s2s.setInputSource(current_scan);
 
   // set pcl::Registration input source for S2M gicp using custom NanoGICP function
-  this->gicp.registerInputSource(this->current_scan);
+  this->gicp.registerInputSource(current_scan);
 
   // now set the KdTree of S2M gicp using previously built KdTree
   this->gicp.source_kdtree_ = this->gicp_s2s.source_kdtree_;
@@ -713,17 +755,26 @@ void OdomNode::initializeDLO() {
 void OdomNode::icpCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& pc) {
 
   double then = this->now().seconds();
-  this->scan_stamp = pc->header.stamp;
-  this->curr_frame_stamp = rclcpp::Time(pc->header.stamp).seconds();
+  const rclcpp::Time scan_stamp = pc->header.stamp;
+  const double curr_frame_stamp = rclcpp::Time(pc->header.stamp).seconds();
 
-  // If there are too few points in the pointcloud, try again
-  this->current_scan = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
-  pcl::fromROSMsg(*pc, *this->current_scan);
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    this->scan_stamp = scan_stamp;
+    this->curr_frame_stamp = curr_frame_stamp;
+  }
 
+  auto current_scan = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
+  pcl::fromROSMsg(*pc, *current_scan);
 
-  if (this->current_scan->points.size() < this->gicp_min_num_points_) {
+  if (current_scan->points.size() < this->gicp_min_num_points_) {
     RCLCPP_WARN(rclcpp::get_logger("DirectLidarOdometry"), "Low number of points!");
     return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    this->current_scan = current_scan;
   }
 
   // DLO Initialization procedures (IMU calib, gravity align)
@@ -769,8 +820,10 @@ void OdomNode::icpCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& pc) {
   }
 
   // Set source frame
-  this->source_cloud = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
-  this->source_cloud = this->current_scan;
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    this->source_cloud = this->current_scan;
+  }
 
   // Set new frame as input source for both gicp objects
   this->setInputSources();
@@ -782,13 +835,22 @@ void OdomNode::icpCB(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& pc) {
   this->updateKeyframes();
 
   // Update trajectory
-  this->trajectory.push_back( std::make_pair(this->pose, this->rotq) );
+  {
+    std::lock_guard<std::mutex> lock(this->trajectory_mutex_);
+    this->trajectory.push_back( std::make_pair(this->pose, this->rotq) );
+  }
 
   // Update next time stamp
-  this->prev_frame_stamp = this->curr_frame_stamp;
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    this->prev_frame_stamp = this->curr_frame_stamp;
+  }
 
   // Update some statistics
-  this->comp_times.push_back(this->now().seconds() - then);
+  {
+    std::lock_guard<std::mutex> lock(this->trajectory_mutex_);
+    this->comp_times.push_back(this->now().seconds() - then);
+  }
 
   // Publish stuff to ROS
   this->publish_thread = std::thread(&OdomNode::publishToROS, this );
@@ -880,9 +942,8 @@ void OdomNode::imuCB(const sensor_msgs::msg::Imu::ConstSharedPtr& imu) {
     this->imu_meas.lin_accel.z = lin_accel[2];
 
     // Store into circular buffer
-    this->mtx_imu.lock();
+    std::lock_guard<std::mutex> lock(this->mtx_imu);
     this->imu_buffer.push_front(this->imu_meas);
-    this->mtx_imu.unlock();
 
   }
 
@@ -904,7 +965,12 @@ void OdomNode::getNextPose() {
 
   if (this->imu_use_) {
     this->integrateIMU();
-    this->gicp_s2s.align(*aligned, this->imu_SE3);
+    Eigen::Matrix4f imu_guess = Eigen::Matrix4f::Identity();
+    {
+      std::lock_guard<std::mutex> lock(this->pose_mutex_);
+      imu_guess = this->imu_SE3;
+    }
+    this->gicp_s2s.align(*aligned, imu_guess);
   } else {
     this->gicp_s2s.align(*aligned);
   }
@@ -938,20 +1004,32 @@ void OdomNode::getNextPose() {
   }
 
   // Align with current submap with global S2S transformation as initial guess
-  this->gicp.align(*aligned, this->T_s2s);
+  Eigen::Matrix4f T_s2s;
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    T_s2s = this->T_s2s;
+  }
+  this->gicp.align(*aligned, T_s2s);
 
   // Get final transformation in global frame
-  this->T = this->gicp.getFinalTransformation();
-
-  // Update the S2S transform for next propagation
-  this->T_s2s_prev = this->T;
+  Eigen::Matrix4f T_global = this->gicp.getFinalTransformation();
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    this->T = T_global;
+    this->T_s2s_prev = this->T;
+  }
 
   // Update next global pose
   // Both source and target clouds are in the global frame now, so tranformation is global
   this->propagateS2M();
 
   // Set next target cloud as current source cloud
-  *this->target_cloud = *this->source_cloud;
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    if (this->target_cloud && this->source_cloud) {
+      *this->target_cloud = *this->source_cloud;
+    }
+  }
 
 }
 
@@ -963,15 +1041,29 @@ void OdomNode::getNextPose() {
 void OdomNode::integrateIMU() {
 
   // Extract IMU data between the two frames
+  std::vector<ImuMeas> imu_buffer_copy;
+  {
+    std::lock_guard<std::mutex> lock(this->mtx_imu);
+    imu_buffer_copy.assign(this->imu_buffer.begin(), this->imu_buffer.end());
+  }
+
+  double curr_frame_stamp = 0.;
+  double prev_frame_stamp = 0.;
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    curr_frame_stamp = this->curr_frame_stamp;
+    prev_frame_stamp = this->prev_frame_stamp;
+  }
+
   std::vector<ImuMeas> imu_frame;
 
-  for (const auto& i : this->imu_buffer) {
+  for (const auto& i : imu_buffer_copy) {
 
     // IMU data between two frames is when:
     //   current frame's timestamp minus imu timestamp is positive
     //   previous frame's timestamp minus imu timestamp is negative
-    double curr_frame_imu_dt = this->curr_frame_stamp - i.stamp;
-    double prev_frame_imu_dt = this->prev_frame_stamp - i.stamp;
+    double curr_frame_imu_dt = curr_frame_stamp - i.stamp;
+    double prev_frame_imu_dt = prev_frame_stamp - i.stamp;
 
     if (curr_frame_imu_dt >= 0. && prev_frame_imu_dt <= 0.) {
 
@@ -1017,8 +1109,13 @@ void OdomNode::integrateIMU() {
   q.w() /= norm; q.x() /= norm; q.y() /= norm; q.z() /= norm;
 
   // Store IMU guess
-  this->imu_SE3 = Eigen::Matrix4f::Identity();
-  this->imu_SE3.block(0, 0, 3, 3) = q.toRotationMatrix();
+  Eigen::Matrix4f imu_SE3 = Eigen::Matrix4f::Identity();
+  imu_SE3.block(0, 0, 3, 3) = q.toRotationMatrix();
+
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    this->imu_SE3 = imu_SE3;
+  }
 
 }
 
@@ -1028,6 +1125,8 @@ void OdomNode::integrateIMU() {
  **/
 
 void OdomNode::propagateS2S(Eigen::Matrix4f T) {
+
+  std::lock_guard<std::mutex> lock(this->pose_mutex_);
 
   this->T_s2s = this->T_s2s_prev * T;
   this->T_s2s_prev = this->T_s2s;
@@ -1053,6 +1152,8 @@ void OdomNode::propagateS2S(Eigen::Matrix4f T) {
 
 void OdomNode::propagateS2M() {
 
+  std::lock_guard<std::mutex> lock(this->pose_mutex_);
+
   this->pose   << this->T(0,3), this->T(1,3), this->T(2,3);
   this->rotSO3 << this->T(0,0), this->T(0,1), this->T(0,2),
                   this->T(1,0), this->T(1,1), this->T(1,2),
@@ -1073,6 +1174,13 @@ void OdomNode::propagateS2M() {
  **/
 
 void OdomNode::transformCurrentScan() {
+  std::scoped_lock lock(this->pose_mutex_, this->cloud_mutex_);
+
+  if (!this->current_scan) {
+    RCLCPP_WARN(this->get_logger(), "Current scan is null. Skipping transform.");
+    return;
+  }
+
   this->current_scan_t = pcl::PointCloud<PointType>::Ptr (new pcl::PointCloud<PointType>);
   pcl::transformPointCloud (*this->current_scan, *this->current_scan_t, this->T);
 }
@@ -1093,23 +1201,43 @@ void OdomNode::computeMetrics() {
 
 void OdomNode::computeSpaciousness() {
 
-  // compute range of points
-  std::vector<float> ds;
+  pcl::PointCloud<PointType>::Ptr current_scan;
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    current_scan = this->current_scan;
+  }
 
-  for (int i = 0; i <= this->current_scan->points.size(); i++) {
-    float d = std::sqrt(pow(this->current_scan->points[i].x, 2) + pow(this->current_scan->points[i].y, 2) + pow(this->current_scan->points[i].z, 2));
-    ds.push_back(d);
+  if (!current_scan || current_scan->empty()) {
+    RCLCPP_WARN(this->get_logger(), "Current scan is empty. Skipping spaciousness computation.");
+    return;
+  }
+
+  // compute range of points
+  std::vector<float> distances;
+  distances.reserve(current_scan->points.size());
+
+  for (const auto& point : current_scan->points) {
+    float d = std::sqrt(point.x * point.x + point.y * point.y + point.z * point.z);
+    distances.push_back(d);
+  }
+
+  if (distances.empty()) {
+    return;
   }
 
   // median
-  std::nth_element(ds.begin(), ds.begin() + ds.size()/2, ds.end());
-  float median_curr = ds[ds.size()/2];
-  static float median_prev = median_curr;
-  float median_lpf = 0.95*median_prev + 0.05*median_curr;
-  median_prev = median_lpf;
+  auto middle_it = distances.begin() + distances.size() / 2;
+  std::nth_element(distances.begin(), middle_it, distances.end());
+  float median_curr = *middle_it;
+  float median_lpf = median_curr;
 
-  // push
-  this->metrics.spaciousness.push_back( median_lpf );
+  {
+    std::lock_guard<std::mutex> metrics_lock(this->metrics_mutex_);
+    float prev = this->metrics.spaciousness.empty() ? median_curr : this->spaciousness_median_prev_;
+    median_lpf = 0.95f * prev + 0.05f * median_curr;
+    this->spaciousness_median_prev_ = median_lpf;
+    this->metrics.spaciousness.push_back(median_lpf);
+  }
 
 }
 
@@ -1203,6 +1331,25 @@ void OdomNode::updateKeyframes() {
   // transform point cloud
   this->transformCurrentScan();
 
+  pcl::PointCloud<PointType>::Ptr current_scan_t;
+  {
+    std::lock_guard<std::mutex> lock(this->cloud_mutex_);
+    current_scan_t = this->current_scan_t;
+  }
+
+  if (!current_scan_t) {
+    RCLCPP_WARN(this->get_logger(), "Transformed scan is null. Skipping keyframe update.");
+    return;
+  }
+
+  Eigen::Vector3f current_pose;
+  Eigen::Quaternionf current_rot;
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    current_pose = this->pose;
+    current_rot = this->rotq;
+  }
+
   // calculate difference in pose and rotation to all poses in trajectory
   float closest_d = std::numeric_limits<float>::infinity();
   int closest_idx = 0;
@@ -1210,76 +1357,86 @@ void OdomNode::updateKeyframes() {
 
   int num_nearby = 0;
 
-  for (const auto& k : this->keyframes) {
+  bool launch_keyframe_thread = false;
 
-    // calculate distance between current pose and pose in keyframes
-    float delta_d = sqrt( pow(this->pose[0] - k.first.first[0], 2) + pow(this->pose[1] - k.first.first[1], 2) + pow(this->pose[2] - k.first.first[2], 2) );
+  {
+    std::lock_guard<std::mutex> key_lock(this->keyframe_mutex_);
 
-    // count the number nearby current pose
-    if (delta_d <= this->keyframe_thresh_dist_ * 1.5){
-      ++num_nearby;
+    for (const auto& k : this->keyframes) {
+
+      // calculate distance between current pose and pose in keyframes
+      float delta_d = sqrt( pow(current_pose[0] - k.first.first[0], 2) + pow(current_pose[1] - k.first.first[1], 2) + pow(current_pose[2] - k.first.first[2], 2) );
+
+      // count the number nearby current pose
+      if (delta_d <= this->keyframe_thresh_dist_ * 1.5){
+        ++num_nearby;
+      }
+
+      // store into variable
+      if (delta_d < closest_d) {
+        closest_d = delta_d;
+        closest_idx = keyframes_idx;
+      }
+
+      keyframes_idx++;
+
     }
 
-    // store into variable
-    if (delta_d < closest_d) {
-      closest_d = delta_d;
-      closest_idx = keyframes_idx;
+    // get closest pose and corresponding rotation
+    Eigen::Vector3f closest_pose = this->keyframes[closest_idx].first.first;
+    Eigen::Quaternionf closest_pose_r = this->keyframes[closest_idx].first.second;
+
+    // calculate distance between current pose and closest pose from above
+    float dd = sqrt( pow(current_pose[0] - closest_pose[0], 2) + pow(current_pose[1] - closest_pose[1], 2) + pow(current_pose[2] - closest_pose[2], 2) );
+
+    // calculate difference in orientation
+    Eigen::Quaternionf dq = current_rot * (closest_pose_r.inverse());
+
+    float theta_rad = 2. * atan2(sqrt( pow(dq.x(), 2) + pow(dq.y(), 2) + pow(dq.z(), 2) ), dq.w());
+    float theta_deg = theta_rad * (180.0/M_PI);
+
+    // update keyframe
+    bool newKeyframe = false;
+
+    if (abs(dd) > this->keyframe_thresh_dist_ || abs(theta_deg) > this->keyframe_thresh_rot_) {
+      newKeyframe = true;
+    }
+    if (abs(dd) <= this->keyframe_thresh_dist_) {
+      newKeyframe = false;
+    }
+    if (abs(dd) <= this->keyframe_thresh_dist_ && abs(theta_deg) > this->keyframe_thresh_rot_ && num_nearby <= 1) {
+      newKeyframe = true;
     }
 
-    keyframes_idx++;
+    if (newKeyframe) {
 
-  }
+      ++this->num_keyframes;
 
-  // get closest pose and corresponding rotation
-  Eigen::Vector3f closest_pose = this->keyframes[closest_idx].first.first;
-  Eigen::Quaternionf closest_pose_r = this->keyframes[closest_idx].first.second;
+      // voxelization for submap
+      if (this->vf_submap_use_) {
+        this->vf_submap.setInputCloud(current_scan_t);
+        this->vf_submap.filter(*current_scan_t);
+      }
 
-  // calculate distance between current pose and closest pose from above
-  float dd = sqrt( pow(this->pose[0] - closest_pose[0], 2) + pow(this->pose[1] - closest_pose[1], 2) + pow(this->pose[2] - closest_pose[2], 2) );
+      // update keyframe vector
+      this->keyframes.push_back(std::make_pair(std::make_pair(current_pose, current_rot), current_scan_t));
 
-  // calculate difference in orientation
-  Eigen::Quaternionf dq = this->rotq * (closest_pose_r.inverse());
+      // compute kdtree and keyframe normals (use gicp_s2s input source as temporary storage because it will be overwritten by setInputSources())
+      *this->keyframes_cloud += *current_scan_t;
+      *this->keyframe_cloud = *current_scan_t;
 
-  float theta_rad = 2. * atan2(sqrt( pow(dq.x(), 2) + pow(dq.y(), 2) + pow(dq.z(), 2) ), dq.w());
-  float theta_deg = theta_rad * (180.0/M_PI);
+      this->gicp_s2s.setInputSource(this->keyframe_cloud);
+      this->gicp_s2s.calculateSourceCovariances();
+      this->keyframe_normals.push_back(this->gicp_s2s.getSourceCovariances());
 
-  // update keyframe
-  bool newKeyframe = false;
+      launch_keyframe_thread = true;
 
-  if (abs(dd) > this->keyframe_thresh_dist_ || abs(theta_deg) > this->keyframe_thresh_rot_) {
-    newKeyframe = true;
-  }
-  if (abs(dd) <= this->keyframe_thresh_dist_) {
-    newKeyframe = false;
-  }
-  if (abs(dd) <= this->keyframe_thresh_dist_ && abs(theta_deg) > this->keyframe_thresh_rot_ && num_nearby <= 1) {
-    newKeyframe = true;
-  }
-
-  if (newKeyframe) {
-
-    ++this->num_keyframes;
-
-    // voxelization for submap
-    if (this->vf_submap_use_) {
-      this->vf_submap.setInputCloud(this->current_scan_t);
-      this->vf_submap.filter(*this->current_scan_t);
     }
+  }
 
-    // update keyframe vector
-    this->keyframes.push_back(std::make_pair(std::make_pair(this->pose, this->rotq), this->current_scan_t));
-
-    // compute kdtree and keyframe normals (use gicp_s2s input source as temporary storage because it will be overwritten by setInputSources())
-    *this->keyframes_cloud += *this->current_scan_t;
-    *this->keyframe_cloud = *this->current_scan_t;
-
-    this->gicp_s2s.setInputSource(this->keyframe_cloud);
-    this->gicp_s2s.calculateSourceCovariances();
-    this->keyframe_normals.push_back(this->gicp_s2s.getSourceCovariances());
-
+  if (launch_keyframe_thread) {
     this->publish_keyframe_thread = std::thread(&OdomNode::publishKeyframe, this );
     this->publish_keyframe_thread.detach();
-
   }
 
 }
@@ -1291,14 +1448,23 @@ void OdomNode::updateKeyframes() {
 
 void OdomNode::setAdaptiveParams() {
 
+  float spaciousness = 0.f;
+  {
+    std::lock_guard<std::mutex> lock(this->metrics_mutex_);
+    if (this->metrics.spaciousness.empty()) {
+      return;
+    }
+    spaciousness = this->metrics.spaciousness.back();
+  }
+
   // Set Keyframe Thresh from Spaciousness Metric
-  if (this->metrics.spaciousness.back() > 20.0){
+  if (spaciousness > 20.0){
     this->keyframe_thresh_dist_ = 10.0;
-  } else if (this->metrics.spaciousness.back() > 10.0 && this->metrics.spaciousness.back() <= 20.0) {
+  } else if (spaciousness > 10.0 && spaciousness <= 20.0) {
     this->keyframe_thresh_dist_ = 5.0;
-  } else if (this->metrics.spaciousness.back() > 5.0 && this->metrics.spaciousness.back() <= 10.0) {
+  } else if (spaciousness > 5.0 && spaciousness <= 10.0) {
     this->keyframe_thresh_dist_ = 1.0;
-  } else if (this->metrics.spaciousness.back() <= 5.0) {
+  } else if (spaciousness <= 5.0) {
     this->keyframe_thresh_dist_ = 0.5;
   }
 
@@ -1345,6 +1511,8 @@ void OdomNode::pushSubmapIndices(std::vector<float> dists, int k, std::vector<in
  **/
 
 void OdomNode::getSubmapKeyframes() {
+
+  std::lock_guard<std::mutex> key_lock(this->keyframe_mutex_);
 
   // clear vector of keyframe indices to use for submap
   this->submap_kf_idx_curr.clear();
@@ -1468,11 +1636,21 @@ bool OdomNode::saveTrajectory(direct_lidar_odometry::save_traj::Request& req,
 
 void OdomNode::debug() {
 
+  std::lock_guard<std::mutex> debug_lock(this->debug_mutex_);
+
   // Total length traversed
   double length_traversed = 0.;
   Eigen::Vector3f p_curr = Eigen::Vector3f(0., 0., 0.);
   Eigen::Vector3f p_prev = Eigen::Vector3f(0., 0., 0.);
-  for (const auto& t : this->trajectory) {
+  std::vector<std::pair<Eigen::Vector3f, Eigen::Quaternionf>> trajectory_copy;
+  std::vector<double> comp_times_copy;
+  {
+    std::lock_guard<std::mutex> lock(this->trajectory_mutex_);
+    trajectory_copy = this->trajectory;
+    comp_times_copy = this->comp_times;
+  }
+
+  for (const auto& t : trajectory_copy) {
     if (p_prev == Eigen::Vector3f(0., 0., 0.)) {
       p_prev = t.first;
       continue;
@@ -1492,7 +1670,10 @@ void OdomNode::debug() {
   }
 
   // Average computation time
-  double avg_comp_time = std::accumulate(this->comp_times.begin(), this->comp_times.end(), 0.0) / this->comp_times.size();
+  double avg_comp_time = 0.0;
+  if (!comp_times_copy.empty()) {
+    avg_comp_time = std::accumulate(comp_times_copy.begin(), comp_times_copy.end(), 0.0) / comp_times_copy.size();
+  }
 
   // RAM Usage
   double vm_usage = 0.0;
@@ -1543,13 +1724,24 @@ void OdomNode::debug() {
   }
 
   std::cout << std::endl << std::setprecision(4) << std::fixed;
-  std::cout << "Position    [xyz]  :: " << this->pose[0] << " " << this->pose[1] << " " << this->pose[2] << std::endl;
-  std::cout << "Orientation [wxyz] :: " << this->rotq.w() << " " << this->rotq.x() << " " << this->rotq.y() << " " << this->rotq.z() << std::endl;
+  Eigen::Vector3f pose;
+  Eigen::Quaternionf rotq;
+  Eigen::Vector3f origin;
+  {
+    std::lock_guard<std::mutex> lock(this->pose_mutex_);
+    pose = this->pose;
+    rotq = this->rotq;
+    origin = this->origin;
+  }
+
+  std::cout << "Position    [xyz]  :: " << pose[0] << " " << pose[1] << " " << pose[2] << std::endl;
+  std::cout << "Orientation [wxyz] :: " << rotq.w() << " " << rotq.x() << " " << rotq.y() << " " << rotq.z() << std::endl;
   std::cout << "Distance Traveled  :: " << length_traversed << " meters" << std::endl;
-  std::cout << "Distance to Origin :: " << sqrt(pow(this->pose[0]-this->origin[0],2) + pow(this->pose[1]-this->origin[1],2) + pow(this->pose[2]-this->origin[2],2)) << " meters" << std::endl;
+  std::cout << "Distance to Origin :: " << sqrt(pow(pose[0]-origin[0],2) + pow(pose[1]-origin[1],2) + pow(pose[2]-origin[2],2)) << " meters" << std::endl;
 
   std::cout << std::endl << std::right << std::setprecision(2) << std::fixed;
-  std::cout << "Computation Time :: " << std::setfill(' ') << std::setw(6) << this->comp_times.back()*1000. << " ms    // Avg: " << std::setw(5) << avg_comp_time*1000. << std::endl;
+  double latest_comp_time_ms = comp_times_copy.empty() ? 0.0 : comp_times_copy.back() * 1000.0;
+  std::cout << "Computation Time :: " << std::setfill(' ') << std::setw(6) << latest_comp_time_ms << " ms    // Avg: " << std::setw(5) << avg_comp_time*1000. << std::endl;
   std::cout << "Cores Utilized   :: " << std::setfill(' ') << std::setw(6) << (cpu_percent/100.) * this->numProcessors << " cores // Avg: " << std::setw(5) << (avg_cpu_usage/100.) * this->numProcessors << std::endl;
   std::cout << "CPU Load         :: " << std::setfill(' ') << std::setw(6) << cpu_percent << " %     // Avg: " << std::setw(5) << avg_cpu_usage << std::endl;
   std::cout << "RAM Allocation   :: " << std::setfill(' ') << std::setw(6) << resident_set/1000. << " MB    // VSZ: " << vm_usage/1000. << " MB" << std::endl;


### PR DESCRIPTION
## Summary
- add dedicated mutexes around odometry pose, cloud, trajectory, metrics, and debug data to avoid concurrent access races
- guard state updates and publishing helpers with scoped locks and local snapshots so detached threads operate on consistent data
- protect map accumulation and publishing with a mutex and add defensive checks for empty scans and transforms

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e64e51cd1c832c828611dca7fa9d7f